### PR TITLE
Failover option, closes #821, closes #830, closes #831

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 coverage
 *.log
 *.rdb
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -205,10 +205,37 @@ The value is provided in milliseconds and is counted once the disconnect occurre
 That way the default is to try reconnecting until 24h passed.
 * `max_attempts`: *0*; By default client will try reconnecting until connected. Setting `max_attempts`
 limits total amount of connection tries. Setting this to 1 will prevent any reconnect tries.
-* `auth_pass`: *null*; If set, client will run redis auth command on connect.
+* `auth_pass`: *null*; If set, client will run redis auth command on connect. If there is no password in redis the driver will log the warning. If the password is enabled in redis at a later point (using `config set requirepass`) the client will seemlessly authenticate when some command fails and reissue the failed command, so there will be no failed command from the application perspective.
 * `family`: *IPv4*; You can force using IPv6 if you set the family to 'IPv6'. See Node.js [net](https://nodejs.org/api/net.html) or [dns](https://nodejs.org/api/dns.html) modules how to use the family type.
 * `disable_resubscribing`: *false*; If set to `true`, a client won't resubscribe after disconnecting
 * `rename_commands`: *null*; pass a object with renamed commands to use those instead of the original functions. See the [redis security topics](http://redis.io/topics/security) for more info.
+* `failover`: *null*; This option allows defining multiple hosts (in `failover.connections`) that the driver will be re-connecting to in order when connection fails. If this option is set, `retry_delay` will only be increasing every time all hosts have been tried. This option also allows defining multiple passwords to the same host. With an additional `failover.readonly` option set as `true` the driver will switch to the next host and re-issue the command when the host becomes readonly slave. Sample options with `failover`:
+
+    ```js
+    {
+        host: 'host1',
+        port: 'port1',
+        auth_pass: 'auth',
+        failover: {
+            connections: [
+                {
+                    auth_path: 'new_auth' // alternative password for the default host1
+                },
+                {
+                    host: 'host2',
+                    port: 'port2',
+                    auth_pass: 'auth'
+                },
+                {
+                    host: 'host2',
+                    port: 'port2',
+                    auth_pass: 'new_auth' // alternative password for host2
+                }
+            ],
+            readonly: true // switch host when it becomes readonly
+        }
+    }
+    ```
 
 ```js
 var redis = require("redis"),

--- a/index.js
+++ b/index.js
@@ -235,11 +235,6 @@ function authenticateLoop(client, passwords, passIndex, callback) {
         passIndex = 0;
     }
 
-    if (!passwords) {
-        callback(new Error('no auth_pass specified'));
-        return;
-    }
-
     send_auth(client, passwords[passIndex], function (err, res) {
         if (err) {
             passIndex++;

--- a/index.js
+++ b/index.js
@@ -35,9 +35,10 @@ try {
 
 parsers.push(require('./lib/parsers/javascript'));
 
-function RedisClient(stream, options) {
+function RedisClient(stream, options, cnxOptions) {
     // Copy the options so they are not mutated
     options = JSON.parse(JSON.stringify(options || {}));
+    this.connectionOption = cnxOptions;
     var self = this;
 
     if (!stream.cork) {
@@ -465,6 +466,7 @@ var retry_connection = function (self) {
     self.attempts += 1;
     self.retry_delay = Math.round(self.retry_delay * self.retry_backoff);
 
+    if (self._failover) failover.nextConnection(self);
     self.stream = net.createConnection(self.connectionOption);
     self.install_stream_listeners();
 
@@ -1221,9 +1223,8 @@ var createClient_unix = function (path, options){
         path: path
     };
     var net_client = net.createConnection(cnxOptions);
-    var redis_client = new RedisClient(net_client, options);
+    var redis_client = new RedisClient(net_client, options, cnxOptions);
 
-    redis_client.connectionOption = cnxOptions;
     redis_client.address = path;
 
     return redis_client;
@@ -1236,9 +1237,8 @@ var createClient_tcp = function (port_arg, host_arg, options) {
         family : options.family === 'IPv6' ? 6 : 4
     };
     var net_client = net.createConnection(cnxOptions);
-    var redis_client = new RedisClient(net_client, options);
+    var redis_client = new RedisClient(net_client, options, cnxOptions);
 
-    redis_client.connectionOption = cnxOptions;
     redis_client.address = cnxOptions.host + ':' + cnxOptions.port;
 
     return redis_client;

--- a/index.js
+++ b/index.js
@@ -226,7 +226,7 @@ function send_auth(client, password, cb) {
 function getPasswords(client) {
     return client._failover ?
             failover.getPasswords(client) :
-            (client.auth_pass ? [client.auth_pass] : undefined);
+            (client.auth_pass === undefined ? undefined : [client.auth_pass]);
 }
 
 function authenticateLoop(client, passwords, passIndex, callback) {

--- a/index.js
+++ b/index.js
@@ -141,13 +141,8 @@ RedisClient.prototype.initialize_retry_vars = function () {
     this.retry_timer = null;
     this.retry_totaltime = 0;
     this.retry_delay = 200;
+    this.retry_backoff = this.options.failover ? 1 : 1.7;
     this.attempts = 1;
-    if (this.options.failover) {
-        this.failover_cycle = 0;
-        this.retry_backoff = 1;
-        this.failover_backoff = 1.7;
-    } else
-        this.retry_backoff = 1.7;
 };
 
 RedisClient.prototype.unref = function () {

--- a/index.js
+++ b/index.js
@@ -230,12 +230,11 @@ function getPasswords(client) {
 }
 
 function authenticateLoop(client, passwords, passIndex, callback) {
-    if (typeof passwords === 'function') {
-        callback = passwords;
-        passwords = undefined;
+    if (typeof passIndex === 'function') {
+        callback = passIndex;
+        passIndex = 0;
     }
-    passwords = passwords || getPasswords(client);
-    passIndex = passIndex || 0;
+
     if (!passwords) {
         callback(new Error('no auth_pass specified'));
         return;
@@ -259,7 +258,7 @@ function authenticateLoop(client, passwords, passIndex, callback) {
 
 RedisClient.prototype.do_auth = function (passwords) {
     var self = this;
-    authenticateLoop(this, passwords, 0, function(err, res) {
+    authenticateLoop(this, passwords, function(err, res) {
         if (err) {
             err.command_used = 'AUTH';
             if (self.auth_callback) {
@@ -629,7 +628,7 @@ RedisClient.prototype.return_error = function (err) {
     if (should_retry_auth) {
         debug('Authentication error, possibly password enabled, try to authenticate');
         var self = this;
-        authenticateLoop(this, passwords, 0, function (e, res) {
+        authenticateLoop(this, passwords, function (e, res) {
             if (e) {
                 _return_error(self, err, command_obj);
             } else {

--- a/lib/failover.js
+++ b/lib/failover.js
@@ -7,8 +7,7 @@ function prepareOptions(client) {
         connections: connections,
         cycle: 0,
         retry_backoff: client.options.failover.retry_backoff || 1.7,
-        connectionIndex: 0,
-        passwordIndex: 0
+        connectionIndex: 0
     };
 
     client.options.failover.connections.forEach(function (cnct) {
@@ -75,9 +74,7 @@ function nextConnection(client) {
     }
     var connection = fo.connections[fo.connectionIndex];
     client.connectionOption = connection.connectionOption;
-
-    fo.passwordIndex = 0;
-    client.auth_pass = connection.auth_pass[fo.passwordIndex];
+    client.auth_pass = connection.auth_pass[0];
 }
 
 
@@ -89,35 +86,6 @@ function getPasswords(client) {
 }
 
 
-function allButCurrent(passwords, currentIndex) {
-    var afterCurrent = passwords.slice(currentIndex + 1);
-    var beforeCurrent = passwords.slice(0, currentIndex);
-    return afterCurrent.concat(beforeCurrent);
-}
-
-
-function alternativePasswords(client) {
-    var fo = client._failover;
-    var connection = fo.connections[fo.connectionIndex];
-    var passwords = connection.auth_pass;
-    if (passwords.length === 1) return;
-    return allButCurrent(passwords, fo.passwordIndex);
-}
-
-
-function setValidPassword(client, password) {
-    var fo = client._failover;
-    var connection = fo.connections[fo.connectionIndex];
-    var index = connection.auth_pass.indexOf(password);
-    var valid = index >= 0;
-    if (valid) fo.passwordIndex = index;
-    else console.error('password doesn\'t match any password defined for the current connection');
-    return valid;
-}
-
-
 exports.prepareOptions = prepareOptions;
 exports.nextConnection = nextConnection;
 exports.getPasswords = getPasswords;
-exports.alternativePasswords = alternativePasswords;
-exports.setValidPassword = setValidPassword;

--- a/lib/failover.js
+++ b/lib/failover.js
@@ -1,16 +1,12 @@
 'use strict';
 
-
-module.exports = {
-    prepareOptions: prepareOptions
-};
-
-
 function prepareOptions(client) {
     var connections = [ { connectionOption: client.connectionOption, auth_pass: [client.options.auth_pass] } ];
 
     client._failover = {
         connections: connections,
+        cycle: 0,
+        retry_backoff: client.options.failover.retry_backoff || 1.7,
         currentConnection: 0,
         currentPass: 0
     };
@@ -19,7 +15,7 @@ function prepareOptions(client) {
         var cnxOption = optionsWithoutAuth(cnct);
         var keys = Object.keys(cnxOption);
         if (keys.length === 0 && cnct.auth_pass) {
-            connections[0].auth_pass.push(cnct.auth_pass);
+            addAuth(cnct.auth_pass, connections[0]);
             return;
         }
 
@@ -33,12 +29,11 @@ function prepareOptions(client) {
         });
 
         if (sameConnection && cnct.auth_pass) {
-            sameConnection.auth_pass.push(cnct.auth_pass);
+            addAuth(cnct.auth_pass, sameConnection)
         } else {
             connections.push({ connectionOption: cnxOption, auth_pass: [cnct.auth_pass]});
         }
     });
-
 
     function optionsWithoutAuth(opts) {
         var options = {};
@@ -48,6 +43,14 @@ function prepareOptions(client) {
             }
         }
         return options;
+    }
+
+    function addAuth(auth_pass, toConnection) {
+        if (toConnection.auth_pass.indexOf(auth_pass) === -1) {
+            toConnection.auth_pass.push(auth_pass);
+        } else {
+            console.error('Same password used more than once');
+        }
     }
 
     function equal(a, b) {
@@ -60,3 +63,25 @@ function prepareOptions(client) {
         return true;
     }
 }
+
+
+function nextConnection(client) {
+    var fo = client._failover;
+    fo.currentConnection++;
+    if (fo.currentConnection === fo.connections.length) {
+        fo.currentConnection = 0;
+        fo.cycle++;
+        client.retry_delay = Math.round(client.retry_delay * fo.retry_backoff);
+    }
+    var connection = fo.connections[fo.currentConnection];
+    client.connectionOption = connection.connectionOption;
+
+    fo.currentPass = 0;
+    var auth_pass = connection.auth_pass[fo.currentPass];
+    if (auth_pass) client.auth_pass = auth_pass;
+    else delete client.auth_pass;
+}
+
+
+exports.prepareOptions = prepareOptions;
+exports.nextConnection = nextConnection;

--- a/lib/failover.js
+++ b/lib/failover.js
@@ -81,6 +81,14 @@ function nextConnection(client) {
 }
 
 
+function getPasswords(client) {
+    var fo = client._failover;
+    var connection = fo.connections[fo.connectionIndex];
+    var passwords = connection.auth_pass;
+    return passwords.filter(function(p) {return p;});
+}
+
+
 function allButCurrent(passwords, currentIndex) {
     var afterCurrent = passwords.slice(currentIndex + 1);
     var beforeCurrent = passwords.slice(0, currentIndex);
@@ -110,5 +118,6 @@ function setValidPassword(client, password) {
 
 exports.prepareOptions = prepareOptions;
 exports.nextConnection = nextConnection;
+exports.getPasswords = getPasswords;
 exports.alternativePasswords = alternativePasswords;
 exports.setValidPassword = setValidPassword;

--- a/lib/failover.js
+++ b/lib/failover.js
@@ -7,8 +7,8 @@ function prepareOptions(client) {
         connections: connections,
         cycle: 0,
         retry_backoff: client.options.failover.retry_backoff || 1.7,
-        currentConnection: 0,
-        currentPass: 0
+        connectionIndex: 0,
+        passwordIndex: 0
     };
 
     client.options.failover.connections.forEach(function (cnct) {
@@ -67,17 +67,17 @@ function prepareOptions(client) {
 
 function nextConnection(client) {
     var fo = client._failover;
-    fo.currentConnection++;
-    if (fo.currentConnection === fo.connections.length) {
-        fo.currentConnection = 0;
+    fo.connectionIndex++;
+    if (fo.connectionIndex === fo.connections.length) {
+        fo.connectionIndex = 0;
         fo.cycle++;
         client.retry_delay = Math.round(client.retry_delay * fo.retry_backoff);
     }
-    var connection = fo.connections[fo.currentConnection];
+    var connection = fo.connections[fo.connectionIndex];
     client.connectionOption = connection.connectionOption;
 
-    fo.currentPass = 0;
-    var auth_pass = connection.auth_pass[fo.currentPass];
+    fo.passwordIndex = 0;
+    var auth_pass = connection.auth_pass[fo.passwordIndex];
     if (auth_pass) client.auth_pass = auth_pass;
     else delete client.auth_pass;
 }

--- a/lib/failover.js
+++ b/lib/failover.js
@@ -1,0 +1,62 @@
+'use strict';
+
+
+module.exports = {
+    prepareOptions: prepareOptions
+};
+
+
+function prepareOptions(client) {
+    var connections = [ { connectionOption: client.connectionOption, auth_pass: [client.options.auth_pass] } ];
+
+    client._failover = {
+        connections: connections,
+        currentConnection: 0,
+        currentPass: 0
+    };
+
+    client.options.failover.connections.forEach(function (cnct) {
+        var cnxOption = optionsWithoutAuth(cnct);
+        var keys = Object.keys(cnxOption);
+        if (keys.length === 0 && cnct.auth_pass) {
+            connections[0].auth_pass.push(cnct.auth_pass);
+            return;
+        }
+
+        var sameConnection, _cnxOption;
+        connections.some(function (_cnct) {
+            _cnxOption = optionsWithoutAuth(_cnct.connectionOption);
+            if (equal(cnxOption, _cnxOption)) {
+                sameConnection = _cnct;
+                return true;
+            }
+        });
+
+        if (sameConnection && cnct.auth_pass) {
+            sameConnection.auth_pass.push(cnct.auth_pass);
+        } else {
+            connections.push({ connectionOption: cnxOption, auth_pass: [cnct.auth_pass]});
+        }
+    });
+
+
+    function optionsWithoutAuth(opts) {
+        var options = {};
+        for (var opt in opts) {
+            if (opt !== 'auth_pass') {
+                options[opt] = opts[opt];
+            }
+        }
+        return options;
+    }
+
+    function equal(a, b) {
+        var keys = Object.keys(a);
+        if (keys.length !== Object.keys(b).length) return false;
+        for (var i = 0; i < keys.length; i++) {
+            var key = keys[i]; 
+            if (a[key] !== b[key]) return false;
+        }
+        return true;
+    }
+}

--- a/lib/failover.js
+++ b/lib/failover.js
@@ -77,9 +77,7 @@ function nextConnection(client) {
     client.connectionOption = connection.connectionOption;
 
     fo.passwordIndex = 0;
-    var auth_pass = connection.auth_pass[fo.passwordIndex];
-    if (auth_pass) client.auth_pass = auth_pass;
-    else delete client.auth_pass;
+    client.auth_pass = connection.auth_pass[fo.passwordIndex];
 }
 
 

--- a/lib/failover.js
+++ b/lib/failover.js
@@ -29,7 +29,7 @@ function prepareOptions(client) {
         });
 
         if (sameConnection && cnct.auth_pass) {
-            addAuth(cnct.auth_pass, sameConnection)
+            addAuth(cnct.auth_pass, sameConnection);
         } else {
             connections.push({ connectionOption: cnxOption, auth_pass: [cnct.auth_pass]});
         }
@@ -83,5 +83,34 @@ function nextConnection(client) {
 }
 
 
+function allButCurrent(passwords, currentIndex) {
+    var afterCurrent = passwords.slice(currentIndex + 1);
+    var beforeCurrent = passwords.slice(0, currentIndex);
+    return afterCurrent.concat(beforeCurrent);
+}
+
+
+function alternativePasswords(client) {
+    var fo = client._failover;
+    var connection = fo.connections[fo.connectionIndex];
+    var passwords = connection.auth_pass;
+    if (passwords.length === 1) return;
+    return allButCurrent(passwords, fo.passwordIndex);
+}
+
+
+function setValidPassword(client, password) {
+    var fo = client._failover;
+    var connection = fo.connections[fo.connectionIndex];
+    var index = connection.auth_pass.indexOf(password);
+    var valid = index >= 0;
+    if (valid) fo.passwordIndex = index;
+    else console.error('password doesn\'t match any password defined for the current connection');
+    return valid;
+}
+
+
 exports.prepareOptions = prepareOptions;
 exports.nextConnection = nextConnection;
+exports.alternativePasswords = alternativePasswords;
+exports.setValidPassword = setValidPassword;

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -50,7 +50,7 @@ describe("client authentication", function () {
                 client.auth(auth + 'bad');
             });
 
-            it.skip("returns an error when auth is bad (empty string) with a callback", function (done) {
+            it("returns an error when auth is bad (empty string) with a callback", function (done) {
                 if (helper.redisProcess().spawnFailed()) this.skip();
 
                 client = redis.createClient.apply(redis.createClient, args);

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -268,6 +268,7 @@ describe("client authentication", function () {
                 });
 
                 it('with options.auth_pass', function (done) {
+                    if (helper.redisProcess().spawnFailed()) this.skip();
                     var args = config.configureClient(parser, ip, {
                         auth_pass: auth,
                         failover: {
@@ -279,6 +280,7 @@ describe("client authentication", function () {
                 });
 
                 it('without options.auth_pass', function (done) {
+                    if (helper.redisProcess().spawnFailed()) this.skip();
                     var args = config.configureClient(parser, ip, {
                         failover: {
                             connections: [

--- a/test/conf/redis2.conf
+++ b/test/conf/redis2.conf
@@ -1,0 +1,4 @@
+port 6380
+bind ::1 127.0.0.1
+unixsocket /tmp/redis2.sock
+unixsocketperm 756

--- a/test/failover.spec.js
+++ b/test/failover.spec.js
@@ -18,7 +18,8 @@ function startRedis2(conf, done) {
 }
 
 
-describe('connection failover', function() {
+(process.platform === 'win32' ? describe.skip : describe)
+('connection failover', function() {
     this.timeout(16000);
 
     function deleteDumpFile() {

--- a/test/failover.spec.js
+++ b/test/failover.spec.js
@@ -19,7 +19,7 @@ function startRedis2(conf, done) {
 
 
 describe('connection failover', function() {
-    this.timeout(12000);
+    this.timeout(16000);
 
     function deleteDumpFile() {
         try { fs.unlinkSync(path.join(__dirname, '..', 'dump.rdb')); } catch(e) {}
@@ -158,7 +158,7 @@ describe('connection failover', function() {
                                             done();
                                         });
                                     });
-                                }, 2000);
+                                }, 4000);
                             });
                         });
                     });

--- a/test/failover.spec.js
+++ b/test/failover.spec.js
@@ -1,0 +1,96 @@
+'use strict';
+
+var assert = require('assert');
+var path = require('path');
+var config = require('./lib/config');
+var RedisProcess = require('./lib/redis-process');
+var helper = require('./helper');
+var redis = config.redis;
+var rp2;
+
+
+function startRedis2(conf, done) {
+    RedisProcess.start(function (err, _rp) {
+        rp2 = _rp;
+        done(err);
+    }, path.resolve(__dirname, conf), { port: 6380, unixsocket: '/tmp/redis2.sock' });
+}
+
+
+describe('connection failover', function() {
+    before(function (done) {
+        startRedis2('./conf/redis2.conf', done);
+    });
+
+    after(function (done) {
+        rp2.stop(done);
+    });
+
+    helper.allTests({
+        allConnections: true
+    }, function(parser, ip, args) {
+        describe('using ' + parser + ' and ' + ip, function () {
+            var client1, client2, clientWithFailover;
+
+            afterEach(function (done) {
+                if (!client1) return done();
+                client1.flushdb(function() {
+                    client2.flushdb(function() {
+                        client1.end();
+                        client2.end();
+                        clientWithFailover.end();
+                        done();
+                    });
+                });
+            });
+
+            it('should switch the connection to the next redis if connection fails', function (done) {
+                client1 = redis.createClient(6379);
+                client2 = redis.createClient(6380);
+                clientWithFailover = redis.createClient(6379, null, {
+                    failover: {
+                        connections: [ { port: 6380 } ]
+                    }
+                });
+
+                onceAll([client1, client2, clientWithFailover], 'ready', function() {
+                    clientWithFailover.on('reconnecting', function() {
+                        clientWithFailover.on('ready', function() {
+                            clientWithFailover.get('failover_key', function (err, res) {
+                                if (err) done(err);
+                                assert.equal(res, undefined);
+                                clientWithFailover.set('failover_key', 'bar', function (err, res) {
+                                    if (err) done(err);
+                                    client2.get('failover_key', function (err, res) {
+                                        if (err) done(err);
+                                        assert.equal(res, 'bar');
+                                        done();
+                                    });
+                                });
+                            });
+                        });
+                    });
+
+                    clientWithFailover.set('failover_key', 'foo', function (err, res) {
+                        if (err) done(err);
+                        client1.get('failover_key', function (err, res) {
+                            if (err) done(err);
+                            assert.equal(res, 'foo');
+                            clientWithFailover.stream.destroy();
+                        });
+                    });
+                });
+            });
+
+            function onceAll(emitters, event, func) {
+                var count = 0;
+                emitters.forEach(function (emitter) {
+                    emitter.once(event, function() {
+                        count++;
+                        if (count === emitters.length) func();
+                    });
+                });
+            }
+        });
+    });
+});

--- a/test/failover.spec.js
+++ b/test/failover.spec.js
@@ -78,6 +78,7 @@ describe('connection failover', function() {
             });
 
             it('should switch the connection to the next redis if connection fails', function (done) {
+                if (rp2.spawnFailed()) this.skip();
                 clientFO.on('reconnecting', function() {
                     clientFO.on('ready', function() {
                         clientFO.get('failover_key', function (err, res) {
@@ -105,6 +106,7 @@ describe('connection failover', function() {
             });
 
             it('should switch back on the second reconnect', function (done) {
+                if (rp2.spawnFailed()) this.skip();
                 var reconnectCount = 0;
                 clientFO.on('reconnecting', function() {
                     clientFO.once('ready', function() {
@@ -140,6 +142,7 @@ describe('connection failover', function() {
                 });
 
                 it('should switch to master if the host becomes slave and write fails', function (done) {
+                    if (rp2.spawnFailed()) this.skip();
                     var reconnectCount = 0;
 
                     clientFO.on('reconnecting', function() {

--- a/test/failover.spec.js
+++ b/test/failover.spec.js
@@ -20,7 +20,7 @@ function startRedis2(conf, done) {
 
 (process.platform === 'win32' ? describe.skip : describe)
 ('connection failover', function() {
-    this.timeout(16000);
+    this.timeout(12000);
 
     function deleteDumpFile() {
         try { fs.unlinkSync(path.join(__dirname, '..', 'dump.rdb')); } catch(e) {}
@@ -154,15 +154,18 @@ function startRedis2(conf, done) {
                             client2.slaveof(masterIP, '6379', function (err, res) {
                                 if (err) return done(err);
                                 setTimeout(function() {
+                                    assert.deepEqual(clientFO.connectionOption, { port: 6380 });
                                     clientFO.set('test_replication', 'bar', function (err, res) {
                                         if (err) return done(err);
-                                        client2.get('test_replication', function (err, res) {
+                                        var co = clientFO.connectionOption;
+                                        assert(co.port === 6379 || co.path === '/tmp/redis.sock');
+                                        client1.get('test_replication', function (err, res) {
                                             if (err) return done(err);
                                             assert.equal(res, 'bar');
                                             done();
                                         });
                                     });
-                                }, 4000);
+                                }, 2000);
                             });
                         });
                     });

--- a/test/failover_auth.spec.js
+++ b/test/failover_auth.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var assert = require('assert');
 var config = require('./lib/config');
 var helper = require('./helper');
 var redis = config.redis;
@@ -42,7 +41,7 @@ describe('failover authentication enable password', function() {
                     client = redis.createClient.apply(redis.createClient, args);
                     testAuth(done);
                 });
-            })
+            });
 
             describe('should fail re-authenticating if different password is enabled', function () {
                 it('with options.auth_pass', function (done) {

--- a/test/failover_auth.spec.js
+++ b/test/failover_auth.spec.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var assert = require('assert');
+var config = require('./lib/config');
+var helper = require('./helper');
+var redis = config.redis;
+
+
+describe('failover authentication enable password', function() {
+    var auth = 'porkchopsandwiches';
+    var client;
+
+    afterEach(function (done) {
+        client.end();
+        done();
+    });
+
+    helper.allTests({ allConnections: true }, function(parser, ip, args) {
+        describe('using ' + parser + ' and ' + ip, function () {
+            afterEach(function (done) {
+                client.config('set', 'requirepass', '', done);
+            });
+
+            it('should re-authenticate if password is enabled in redis', function (done) {
+                var args = config.configureClient(parser, ip, {
+                    auth_pass: auth
+                });
+                client = redis.createClient.apply(redis.createClient, args);
+
+                client.on('ready', function() {
+                    helper.testSet(client, 1, function (err) {
+                        if (err) return done(err);
+                        client.config('set', 'requirepass', auth, function (err) {
+                            if (err) return done(err);
+                            helper.testSet(client, 2, done);
+                        });
+                    });
+                });
+            });
+
+            it('should fail re-authenticating if different password is enabled', function (done) {
+                var args = config.configureClient(parser, ip, {
+                    auth_pass: auth
+                });
+                client = redis.createClient.apply(redis.createClient, args);
+
+                client.on('ready', function() {
+                    helper.testSet(client, 1, function (err) {
+                        if (err) return done(err);
+                        client.config('set', 'requirepass', 'another_auth', function (err) {
+                            if (err) return done(err);
+                            helper.testSet(client, 2, function (err) {
+                                if (err) {
+                                    client.auth('another_auth', done);
+                                } else {
+                                    done(new Error('it should have failed'));
+                                }
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/failover_options.spec.js
+++ b/test/failover_options.spec.js
@@ -3,7 +3,6 @@
 var failover = require('../lib/failover');
 var assert = require('assert');
 
-
 function CLIENT_2_CONN_NO_AUTH() {
     return {
         connectionOption: {
@@ -56,7 +55,7 @@ function CLIENT_2_CONN_WITH_AUTH() {
 }
 
 
-describe.only('failover', function() {
+describe('failover options', function() {
     describe('prepareOptions', function() {
         it('should convert options to enable redis password', function() {
             var client = {
@@ -244,7 +243,7 @@ describe.only('failover', function() {
                 assert.deepEqual(client.connectionOption, { host: 'host2', port: 6380 });
                 assert.equal(client._failover.cycle, 0);
                 assert.equal(client.retry_delay, 200);
-                assert(!client.hasOwnProperty('auth_pass'));
+                assert.equal(client.auth_pass, undefined);
             });
 
             it('should switch back to the first connection after the second call', function() {
@@ -254,7 +253,7 @@ describe.only('failover', function() {
                 assert.deepEqual(client.connectionOption, { host: 'host1', port: 6379 });
                 assert.equal(client._failover.cycle, 1);
                 assert.equal(client.retry_delay, 200 * client._failover.retry_backoff);
-                assert(!client.hasOwnProperty('auth_pass'));
+                assert.equal(client.auth_pass, undefined);
             });
         });
 

--- a/test/failover_options.spec.js
+++ b/test/failover_options.spec.js
@@ -265,9 +265,7 @@ describe('failover options', function() {
                 failover.prepareOptions(client);
             });
 
-            it('should switch to the next connection using the first password', function() {
-                // password is already switched
-                client._failover.passwordIndex = 1;
+            it('should switch to the next connection', function() {
                 client.auth_pass = 'new_pass1';
 
                 failover.nextConnection(client);
@@ -276,12 +274,9 @@ describe('failover options', function() {
                 assert.equal(client.auth_pass, 'current_pass2');
                 assert.equal(client._failover.cycle, 0);
                 assert.equal(client._failover.connectionIndex, 1);
-                assert.equal(client._failover.passwordIndex, 0);
             });
 
-            it('should switch back to the first connection after the second call (using the first password)', function() {
-                // password is already switched
-                client._failover.passwordIndex = 1;
+            it('should switch back to the first connection after the second call', function() {
                 client.auth_pass = 'new_pass1';
 
                 failover.nextConnection(client);
@@ -291,96 +286,7 @@ describe('failover options', function() {
                 assert.equal(client.auth_pass, 'current_pass1');
                 assert.equal(client._failover.cycle, 1);
                 assert.equal(client._failover.connectionIndex, 0);
-                assert.equal(client._failover.passwordIndex, 0);
             });
-        });
-    });
-
-    describe('alternativePasswords', function() {
-        it('should return undefined without multiple auth_pass', function() {
-            var client = CLIENT_2_CONN_NO_AUTH();
-            failover.prepareOptions(client);
-
-            var passwords = failover.alternativePasswords(client);
-            assert.equal(passwords, undefined);
-        });
-
-        it('should return all passwords of the current connection but current', function() {
-            var client = CLIENT_2_CONN_WITH_AUTH();
-            failover.prepareOptions(client);
-
-            var passwords = failover.alternativePasswords(client);
-            assert.deepEqual(passwords, ['new_pass1']);
-        });
-    });
-
-    describe('setValidPassword', function() {
-        it('should set the index of valid password', function() {
-            var client = {
-                connectionOption: {
-                    host: 'localhost',
-                    port: 6379
-                },
-                auth_pass: 'current_pass', // client constructor copies it here from options
-                options: {
-                    auth_pass: 'current_pass',
-                    failover: {
-                        connections: [
-                            {
-                                auth_pass: 'new_pass1',
-                            },
-                            {
-                                auth_pass: 'new_pass2'
-                            }
-                        ]
-                    }
-                }
-            };
-            failover.prepareOptions(client);
-            assert.equal(client._failover.passwordIndex, 0);
-
-            var passwords = failover.alternativePasswords(client);
-            assert.deepEqual(passwords, ['new_pass1', 'new_pass2']);
-
-            var valid = failover.setValidPassword(client, 'new_pass1');
-            assert.equal(valid, true);
-            assert.equal(client._failover.passwordIndex, 1);
-
-            passwords = failover.alternativePasswords(client);
-            assert.deepEqual(passwords, ['new_pass2', 'current_pass']);
-
-            valid = failover.setValidPassword(client, 'current_pass');
-            assert.equal(valid, true);
-            assert.equal(client._failover.passwordIndex, 0);
-        });
-
-        it('should return false if passed password was not defined for the current connection', function() {
-            var client = {
-                connectionOption: {
-                    host: 'localhost',
-                    port: 6379
-                },
-                auth_pass: 'current_pass', // client constructor copies it here from options
-                options: {
-                    auth_pass: 'current_pass',
-                    failover: {
-                        connections: [
-                            {
-                                auth_pass: 'new_pass1',
-                            },
-                            {
-                                auth_pass: 'new_pass2'
-                            }
-                        ]
-                    }
-                }
-            };
-            failover.prepareOptions(client);
-            assert.equal(client._failover.passwordIndex, 0);
-
-            var valid = failover.setValidPassword(client, 'another_password');
-            assert.equal(valid, false);
-            assert.equal(client._failover.passwordIndex, 0);
         });
     });
 });

--- a/test/failover_options.spec.js
+++ b/test/failover_options.spec.js
@@ -1,0 +1,179 @@
+'use strict';
+
+
+var failover = require('../lib/failover');
+var assert = require('assert');
+
+
+describe('failover.prepareOptions', function() {
+    it('should convert options to enable redis password', function() {
+        var client = {
+            connectionOption: {
+                host: 'localhost',
+                port: 6379
+            },
+            options: {
+                failover: {
+                    connections: [
+                        { auth_pass: 'new_password' }
+                    ]
+                }
+            }
+        };
+
+        failover.prepareOptions(client);
+
+        assert.deepEqual(client._failover, {
+            connections: [
+                {
+                    connectionOption: {
+                        host: 'localhost',
+                        port: 6379
+                    },
+                    auth_pass: [ undefined, 'new_password' ]
+                }
+            ],
+            currentConnection: 0,
+            currentPass: 0
+        });
+    });
+
+
+    it('should convert options to change redis password', function() {
+        var client = {
+            connectionOption: {
+                host: 'localhost',
+                port: 6379
+            },
+            options: {
+                auth_pass: 'current_pass',
+                failover: {
+                    connections: [
+                        { auth_pass: 'new_password' }
+                    ]
+                }
+            }
+        };
+
+        failover.prepareOptions(client);
+
+        assert.deepEqual(client._failover, {
+            connections: [
+                {
+                    connectionOption: {
+                        host: 'localhost',
+                        port: 6379
+                    },
+                    auth_pass: [ 'current_pass', 'new_password' ]
+                }
+            ],
+            currentConnection: 0,
+            currentPass: 0
+        });
+    });
+
+
+    it('should convert options to switch to another host', function() {
+        var client = {
+            connectionOption: {
+                host: 'host1',
+                port: 6379
+            },
+            options: {
+                failover: {
+                    connections: [
+                        {
+                            host: 'host2',
+                            port: 6379
+                        }
+                    ]
+                }
+            }
+        };
+
+        failover.prepareOptions(client);
+
+        assert.deepEqual(client._failover, {
+            connections: [
+                {
+                    connectionOption: {
+                        host: 'host1',
+                        port: 6379
+                    },
+                    auth_pass: [ undefined ]
+                },
+                {
+                    connectionOption: {
+                        host: 'host2',
+                        port: 6379
+                    },
+                    auth_pass: [ undefined ]
+                }
+            ],
+            currentConnection: 0,
+            currentPass: 0
+        });
+    });
+
+
+    it('should group auth_pass by connection options', function() {
+        var client = {
+            connectionOption: {
+                host: 'host1',
+                port: 6379
+            },
+            options: {
+                auth_pass: 'current_pass1',
+                failover: {
+                    connections: [
+                        {
+                            auth_pass: 'new_pass1',
+                        },
+                        {
+                            host: 'host2',
+                            port: 6379,
+                            auth_pass: 'current_pass2'
+                        },
+                        {
+                            host: 'host2',
+                            port: 6379,
+                            auth_pass: 'new_pass2'
+                        },
+                        {
+                            port: 6380
+                        }
+                    ]
+                }
+            }
+        };
+
+        failover.prepareOptions(client);
+
+        assert.deepEqual(client._failover, {
+            connections: [
+                {
+                    connectionOption: {
+                        host: 'host1',
+                        port: 6379
+                    },
+                    auth_pass: [ 'current_pass1', 'new_pass1' ]
+                },
+                {
+                    connectionOption: {
+                        host: 'host2',
+                        port: 6379
+                    },
+                    auth_pass: [ 'current_pass2', 'new_pass2' ]
+                },
+                {
+                    connectionOption: {
+                        port: 6380
+                    },
+                    auth_pass: [ undefined ]
+                }
+            ],
+            currentConnection: 0,
+            currentPass: 0
+        });
+    });
+});

--- a/test/failover_options.spec.js
+++ b/test/failover_options.spec.js
@@ -277,7 +277,7 @@ describe.only('failover', function() {
 
             it('should switch to the next connection using the first password', function() {
                 // password is already switched
-                client._failover.currentPass = 1;
+                client._failover.passwordIndex = 1;
                 client.auth_pass = 'new_pass1';
 
                 failover.nextConnection(client);
@@ -285,13 +285,13 @@ describe.only('failover', function() {
                 assert.deepEqual(client.connectionOption, { host: 'host2', port: 6380 });
                 assert.equal(client.auth_pass, 'current_pass2');
                 assert.equal(client._failover.cycle, 0);
-                assert.equal(client._failover.currentConnection, 1);
-                assert.equal(client._failover.currentPass, 0);
+                assert.equal(client._failover.connectionIndex, 1);
+                assert.equal(client._failover.passwordIndex, 0);
             });
 
             it('should switch back to the first connection after the second call (using the first password)', function() {
                 // password is already switched
-                client._failover.currentPass = 1;
+                client._failover.passwordIndex = 1;
                 client.auth_pass = 'new_pass1';
 
                 failover.nextConnection(client);
@@ -300,8 +300,8 @@ describe.only('failover', function() {
                 assert.deepEqual(client.connectionOption, { host: 'host1', port: 6379 });
                 assert.equal(client.auth_pass, 'current_pass1');
                 assert.equal(client._failover.cycle, 1);
-                assert.equal(client._failover.currentConnection, 0);
-                assert.equal(client._failover.currentPass, 0);
+                assert.equal(client._failover.connectionIndex, 0);
+                assert.equal(client._failover.passwordIndex, 0);
             });
         });
     });

--- a/test/failover_options.spec.js
+++ b/test/failover_options.spec.js
@@ -5,26 +5,26 @@ var failover = require('../lib/failover');
 var assert = require('assert');
 
 
-describe('failover.prepareOptions', function() {
-    it('should convert options to enable redis password', function() {
-        var client = {
-            connectionOption: {
-                host: 'localhost',
-                port: 6379
-            },
-            options: {
-                failover: {
-                    connections: [
-                        { auth_pass: 'new_password' }
-                    ]
+describe.only('failover', function() {
+    describe('prepareOptions', function() {
+        it('should convert options to enable redis password', function() {
+            var client = {
+                connectionOption: {
+                    host: 'localhost',
+                    port: 6379
+                },
+                options: {
+                    failover: {
+                        connections: [
+                            { auth_pass: 'new_password' }
+                        ]
+                    }
                 }
-            }
-        };
+            };
 
-        failover.prepareOptions(client);
+            failover.prepareOptions(client);
 
-        assert.deepEqual(client._failover, {
-            connections: [
+            assert.deepEqual(client._failover.connections, [
                 {
                     connectionOption: {
                         host: 'localhost',
@@ -32,33 +32,29 @@ describe('failover.prepareOptions', function() {
                     },
                     auth_pass: [ undefined, 'new_password' ]
                 }
-            ],
-            currentConnection: 0,
-            currentPass: 0
+            ]);
         });
-    });
 
 
-    it('should convert options to change redis password', function() {
-        var client = {
-            connectionOption: {
-                host: 'localhost',
-                port: 6379
-            },
-            options: {
-                auth_pass: 'current_pass',
-                failover: {
-                    connections: [
-                        { auth_pass: 'new_password' }
-                    ]
+        it('should convert options to change redis password', function() {
+            var client = {
+                connectionOption: {
+                    host: 'localhost',
+                    port: 6379
+                },
+                options: {
+                    auth_pass: 'current_pass',
+                    failover: {
+                        connections: [
+                            { auth_pass: 'new_password' }
+                        ]
+                    }
                 }
-            }
-        };
+            };
 
-        failover.prepareOptions(client);
+            failover.prepareOptions(client);
 
-        assert.deepEqual(client._failover, {
-            connections: [
+            assert.deepEqual(client._failover.connections, [
                 {
                     connectionOption: {
                         host: 'localhost',
@@ -66,35 +62,61 @@ describe('failover.prepareOptions', function() {
                     },
                     auth_pass: [ 'current_pass', 'new_password' ]
                 }
-            ],
-            currentConnection: 0,
-            currentPass: 0
+            ]);
         });
-    });
 
 
-    it('should convert options to switch to another host', function() {
-        var client = {
-            connectionOption: {
-                host: 'host1',
-                port: 6379
-            },
-            options: {
-                failover: {
-                    connections: [
-                        {
-                            host: 'host2',
-                            port: 6379
-                        }
-                    ]
+        it('should not use the same password twice', function() {
+            var client = {
+                connectionOption: {
+                    host: 'localhost',
+                    port: 6379
+                },
+                options: {
+                    auth_pass: 'current_pass',
+                    failover: {
+                        connections: [
+                            { auth_pass: 'current_pass' }
+                        ]
+                    }
                 }
-            }
-        };
+            };
 
-        failover.prepareOptions(client);
+            failover.prepareOptions(client);
 
-        assert.deepEqual(client._failover, {
-            connections: [
+            assert.deepEqual(client._failover.connections, [
+                {
+                    connectionOption: {
+                        host: 'localhost',
+                        port: 6379
+                    },
+                    auth_pass: [ 'current_pass' ]
+                }
+            ]);
+        });
+
+
+        it('should convert options to switch to another host', function() {
+            var client = {
+                connectionOption: {
+                    host: 'host1',
+                    port: 6379
+                },
+                options: {
+                    failover: {
+                        connections: [
+                            {
+                                host: 'host2',
+                                port: 6380
+                            }
+                        ]
+                    }
+                }
+            };
+
+            failover.prepareOptions(client);
+
+            assert.deepEqual(client._failover.connections, [
                 {
                     connectionOption: {
                         host: 'host1',
@@ -105,52 +127,48 @@ describe('failover.prepareOptions', function() {
                 {
                     connectionOption: {
                         host: 'host2',
-                        port: 6379
+                        port: 6380
                     },
                     auth_pass: [ undefined ]
                 }
-            ],
-            currentConnection: 0,
-            currentPass: 0
+            ]);
         });
-    });
 
 
-    it('should group auth_pass by connection options', function() {
-        var client = {
-            connectionOption: {
-                host: 'host1',
-                port: 6379
-            },
-            options: {
-                auth_pass: 'current_pass1',
-                failover: {
-                    connections: [
-                        {
-                            auth_pass: 'new_pass1',
-                        },
-                        {
-                            host: 'host2',
-                            port: 6379,
-                            auth_pass: 'current_pass2'
-                        },
-                        {
-                            host: 'host2',
-                            port: 6379,
-                            auth_pass: 'new_pass2'
-                        },
-                        {
-                            port: 6380
-                        }
-                    ]
+        it('should group auth_pass by connection options', function() {
+            var client = {
+                connectionOption: {
+                    host: 'host1',
+                    port: 6379
+                },
+                options: {
+                    auth_pass: 'current_pass1',
+                    failover: {
+                        connections: [
+                            {
+                                auth_pass: 'new_pass1',
+                            },
+                            {
+                                host: 'host2',
+                                port: 6380,
+                                auth_pass: 'current_pass2'
+                            },
+                            {
+                                host: 'host2',
+                                port: 6380,
+                                auth_pass: 'new_pass2'
+                            },
+                            {
+                                port: 6381
+                            }
+                        ]
+                    }
                 }
-            }
-        };
+            };
 
-        failover.prepareOptions(client);
+            failover.prepareOptions(client);
 
-        assert.deepEqual(client._failover, {
-            connections: [
+            assert.deepEqual(client._failover.connections, [
                 {
                     connectionOption: {
                         host: 'host1',
@@ -161,19 +179,130 @@ describe('failover.prepareOptions', function() {
                 {
                     connectionOption: {
                         host: 'host2',
-                        port: 6379
+                        port: 6380
                     },
                     auth_pass: [ 'current_pass2', 'new_pass2' ]
                 },
                 {
                     connectionOption: {
-                        port: 6380
+                        port: 6381
                     },
                     auth_pass: [ undefined ]
                 }
-            ],
-            currentConnection: 0,
-            currentPass: 0
+            ]);
+        });
+    });
+
+
+    describe('nextConnection', function() {
+        describe('without authentication', function() {
+            var client;
+
+            beforeEach(function() {
+                client = {
+                    connectionOption: {
+                        host: 'host1',
+                        port: 6379
+                    },
+                    options: {
+                        failover: {
+                            connections: [
+                                {
+                                    host: 'host2',
+                                    port: 6380
+                                }
+                            ]
+                        }
+                    },
+                    retry_delay: 200
+                };
+
+                failover.prepareOptions(client);
+            });
+
+            it('should switch to the next connection', function() {
+                failover.nextConnection(client);
+
+                assert.deepEqual(client.connectionOption, { host: 'host2', port: 6380 });
+                assert.equal(client._failover.cycle, 0);
+                assert.equal(client.retry_delay, 200);
+                assert(!client.hasOwnProperty('auth_pass'));
+            });
+
+            it('should switch back to the first connection after the second call', function() {
+                failover.nextConnection(client);
+                failover.nextConnection(client);
+
+                assert.deepEqual(client.connectionOption, { host: 'host1', port: 6379 });
+                assert.equal(client._failover.cycle, 1);
+                assert.equal(client.retry_delay, 200 * client._failover.retry_backoff);
+                assert(!client.hasOwnProperty('auth_pass'));
+            });
+        });
+
+        describe('with authentication', function() {
+            var client;
+
+            beforeEach(function() {
+                client = {
+                    connectionOption: {
+                        host: 'host1',
+                        port: 6379
+                    },
+                    auth_pass: 'current_pass1', // client constructor copies it here from options
+                    options: {
+                        auth_pass: 'current_pass1',
+                        failover: {
+                            connections: [
+                                {
+                                    auth_pass: 'new_pass1',
+                                },
+                                {
+                                    host: 'host2',
+                                    port: 6380,
+                                    auth_pass: 'current_pass2'
+                                },
+                                {
+                                    host: 'host2',
+                                    port: 6380,
+                                    auth_pass: 'new_pass2'
+                                }
+                            ]
+                        }
+                    }
+                };
+
+                failover.prepareOptions(client);
+            });
+
+            it('should switch to the next connection using the first password', function() {
+                // password is already switched
+                client._failover.currentPass = 1;
+                client.auth_pass = 'new_pass1';
+
+                failover.nextConnection(client);
+
+                assert.deepEqual(client.connectionOption, { host: 'host2', port: 6380 });
+                assert.equal(client.auth_pass, 'current_pass2');
+                assert.equal(client._failover.cycle, 0);
+                assert.equal(client._failover.currentConnection, 1);
+                assert.equal(client._failover.currentPass, 0);
+            });
+
+            it('should switch back to the first connection after the second call (using the first password)', function() {
+                // password is already switched
+                client._failover.currentPass = 1;
+                client.auth_pass = 'new_pass1';
+
+                failover.nextConnection(client);
+                failover.nextConnection(client);
+
+                assert.deepEqual(client.connectionOption, { host: 'host1', port: 6379 });
+                assert.equal(client.auth_pass, 'current_pass1');
+                assert.equal(client._failover.cycle, 1);
+                assert.equal(client._failover.currentConnection, 0);
+                assert.equal(client._failover.currentPass, 0);
+            });
         });
     });
 });

--- a/test/helper.js
+++ b/test/helper.js
@@ -146,8 +146,8 @@ module.exports = {
         });
     },
     testSet: function (client, value, cb) {
-        var key = 'test_key_' + value,
-            value = 'test_value_' + value;
+        var key = 'test_key_' + value;
+        value = 'test_value_' + value;
         client.set(key, value, function (err, res) {
             if (err) return cb(err);
             assert.equal(res, 'OK');

--- a/test/helper.js
+++ b/test/helper.js
@@ -145,6 +145,23 @@ module.exports = {
             });
         });
     },
+    testSet: function (client, value, cb) {
+        var key = 'test_key_' + value,
+            value = 'test_value_' + value;
+        client.set(key, value, function (err, res) {
+            if (err) return cb(err);
+            assert.equal(res, 'OK');
+            client.get(key, function (err, res) {
+                if (err) return cb(err);
+                assert.equal(res, value);
+                client.del(key, function (err, res) {
+                    if (err) return cb(err);
+                    assert.equal(res, 1);
+                    cb();
+                });
+            });
+        });
+    },
     removeMochaListener: function () {
         var mochaListener = process.listeners('uncaughtException').pop();
         process.removeListener('uncaughtException', mochaListener);

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -24,8 +24,8 @@ var config = {
         if (ip.match(/\.sock/)) {
             args.push(ip);
         } else {
-            args.push(config.PORT);
-            args.push(config.HOST[ip]);
+            args.push(opts.port || config.PORT);
+            args.push(opts.host || config.HOST[ip]);
             opts.family = ip;
         }
 


### PR DESCRIPTION
@BridgeAR This implements all the discussed features within failover option:
1. Switching to another host when connection fails
2. Switching to another host when it becomes readonly (with additional failover.readonly option) (#830)
3. Seamlessly authenticating when the password was enabled in redis without failing the command (#821)
4 Supporting multiple passwords per host so that when the password is changed and the driver reconnects the connection is successful (#821)

It includes all the functionality from #831

After the last merge from the upstream I have difficulties running tests locally, I expect the tests to fail for this PR - will be fixing them.

Help is appreciated :)
