### PR TITLE
[AsyncLocalStorage] getStore() return undefine after call redis command

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -2,11 +2,34 @@
 
 var betterStackTraces = /development/i.test(process.env.NODE_ENV) || /\bredis\b/i.test(process.env.NODE_DEBUG);
 
-function Command (command, args, callback, call_on_write) {
+var AsyncResource
+var executionAsyncId
+
+try {
+    var asyncHooks = require("async_hooks");
+    //asyncResource.runInAsyncScope added since node v9.6.0
+    if (typeof asyncHooks.AsyncResource.prototype.runInAsyncScope === "function") {
+        AsyncResource = asyncHooks.AsyncResource;
+        executionAsyncId = asyncHooks.executionAsyncId;
+    }
+} catch (e) { }
+
+function Command(command, args, callback, call_on_write) {
     this.command = command;
     this.args = args;
     this.buffer_args = false;
-    this.callback = callback;
+
+    if (AsyncResource && typeof callback === 'function') {
+        var asyncResource = new AsyncResource('redis', executionAsyncId())
+        var callbackWrapper = function (...args) {
+            asyncResource.runInAsyncScope(callback, this, ...args);
+            asyncResource.emitDestroy();
+        }
+        this.callback = callbackWrapper;
+    } else {
+        this.callback = callback;
+    }
+
     this.call_on_write = call_on_write;
     if (betterStackTraces) {
         this.error = new Error();

--- a/lib/command.js
+++ b/lib/command.js
@@ -14,7 +14,7 @@ try {
     }
 } catch (e) { debug('not support'); }
 
-function Command(command, args, callback, call_on_write) {
+function Command (command, args, callback, call_on_write) {
     this.command = command;
     this.args = args;
     this.buffer_args = false;

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,30 +1,36 @@
 'use strict';
 
+var debug = require('./debug');
 var betterStackTraces = /development/i.test(process.env.NODE_ENV) || /\bredis\b/i.test(process.env.NODE_DEBUG);
 
-var AsyncResource
-var executionAsyncId
+var AsyncResource;
+var executionAsyncId;
 
 try {
-    var asyncHooks = require("async_hooks");
-    //asyncResource.runInAsyncScope added since node v9.6.0
-    if (typeof asyncHooks.AsyncResource.prototype.runInAsyncScope === "function") {
+    var asyncHooks = require('async_hooks');
+    if (typeof asyncHooks.AsyncResource.prototype.runInAsyncScope === 'function') {
         AsyncResource = asyncHooks.AsyncResource;
         executionAsyncId = asyncHooks.executionAsyncId;
     }
-} catch (e) { }
+} catch (e) { debug('not support'); }
 
-function Command(command, args, callback, call_on_write) {
+function Command (command, args, callback, call_on_write) {
     this.command = command;
     this.args = args;
     this.buffer_args = false;
 
     if (AsyncResource && typeof callback === 'function') {
-        var asyncResource = new AsyncResource('redis', executionAsyncId())
-        var callbackWrapper = function (...args) {
-            asyncResource.runInAsyncScope(callback, this, ...args);
+        var asyncResource = new AsyncResource('redis', executionAsyncId());
+        var callbackWrapper = function () {
+            // asyncResource.runInAsyncScope(callback, this, ...arguments); // eslint rules does not allow es6
+            var params = [callback, this];
+            if (arguments && arguments.length > 0) {
+                for (var i = 0; i < arguments.length; ++i)
+                    params.push(arguments[i]);
+            }
+            asyncResource.runInAsyncScope.apply(asyncResource, params);
             asyncResource.emitDestroy();
-        }
+        };
         this.callback = callbackWrapper;
     } else {
         this.callback = callback;

--- a/lib/command.js
+++ b/lib/command.js
@@ -22,14 +22,19 @@ function Command (command, args, callback, call_on_write) {
     if (AsyncResource && typeof callback === 'function') {
         var asyncResource = new AsyncResource('redis', executionAsyncId());
         var callbackWrapper = function () {
-            // asyncResource.runInAsyncScope(callback, this, ...arguments); // es6 rules not allow
-            var params = [callback, this];
-            if (arguments && arguments.length > 0) {
-                for (var i = 0; i < arguments.length; ++i)
-                    params.push(arguments[i]);
+            try {
+                // asyncResource.runInAsyncScope(callback, this, ...arguments); // es6 rules not allow
+                var params = [callback, this];
+                if (arguments && arguments.length > 0) {
+                    for (var i = 0; i < arguments.length; ++i)
+                        params.push(arguments[i]);
+                }
+                asyncResource.runInAsyncScope.apply(asyncResource, params);
+                asyncResource.emitDestroy();
+            } catch (err) {
+                asyncResource.emitDestroy();
+                throw err;
             }
-            asyncResource.runInAsyncScope.apply(asyncResource, params);
-            asyncResource.emitDestroy();
         };
         this.callback = callbackWrapper;
     } else {

--- a/lib/command.js
+++ b/lib/command.js
@@ -14,7 +14,7 @@ try {
     }
 } catch (e) { debug('not support'); }
 
-function Command (command, args, callback, call_on_write) {
+function Command(command, args, callback, call_on_write) {
     this.command = command;
     this.args = args;
     this.buffer_args = false;
@@ -22,7 +22,7 @@ function Command (command, args, callback, call_on_write) {
     if (AsyncResource && typeof callback === 'function') {
         var asyncResource = new AsyncResource('redis', executionAsyncId());
         var callbackWrapper = function () {
-            // asyncResource.runInAsyncScope(callback, this, ...arguments); // eslint rules does not allow es6
+            // asyncResource.runInAsyncScope(callback, this, ...arguments); // es6 rules not allow
             var params = [callback, this];
             if (arguments && arguments.length > 0) {
                 for (var i = 0; i < arguments.length; ++i)

--- a/lib/command.js
+++ b/lib/command.js
@@ -20,14 +20,13 @@ function Command (command, args, callback, call_on_write) {
     this.command = command;
     this.args = args;
     this.buffer_args = false;
-
     if (isSupported && typeof callback === 'function') {
         var asyncResource = new AsyncResource('redis', executionAsyncId());
         this.callback = function () {
             try {
                 // asyncResource.runInAsyncScope(callback, this, ...arguments); // es6 rules not allow
                 var params = [callback, this];
-                if (arguments && arguments.length > 0) {
+                if (arguments.length > 0) {
                     for (var i = 0; i < arguments.length; ++i)
                         params.push(arguments[i]);
                 }
@@ -41,7 +40,6 @@ function Command (command, args, callback, call_on_write) {
     } else {
         this.callback = callback;
     }
-
     this.call_on_write = call_on_write;
     if (betterStackTraces) {
         this.error = new Error();

--- a/lib/command.js
+++ b/lib/command.js
@@ -25,14 +25,10 @@ function Command (command, args, callback, call_on_write) {
         this.callback = function () {
             try {
                 // asyncResource.runInAsyncScope(callback, this, ...arguments);
-                var params = [callback, this];
-                for (var i = 0; i < arguments.length; ++i)
-                    params.push(arguments[i]);
+                var params = [callback, this].concat(Array.from(arguments));
                 asyncResource.runInAsyncScope.apply(asyncResource, params);
+            } finally {
                 asyncResource.emitDestroy();
-            } catch (err) {
-                asyncResource.emitDestroy();
-                throw err;
             }
         };
     } else {

--- a/lib/command.js
+++ b/lib/command.js
@@ -24,12 +24,10 @@ function Command (command, args, callback, call_on_write) {
         var asyncResource = new AsyncResource('redis', executionAsyncId());
         this.callback = function () {
             try {
-                // asyncResource.runInAsyncScope(callback, this, ...arguments); // es6 rules not allow
+                // asyncResource.runInAsyncScope(callback, this, ...arguments);
                 var params = [callback, this];
-                if (arguments.length > 0) {
-                    for (var i = 0; i < arguments.length; ++i)
-                        params.push(arguments[i]);
-                }
+                for (var i = 0; i < arguments.length; ++i)
+                    params.push(arguments[i]);
                 asyncResource.runInAsyncScope.apply(asyncResource, params);
                 asyncResource.emitDestroy();
             } catch (err) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -5,23 +5,25 @@ var betterStackTraces = /development/i.test(process.env.NODE_ENV) || /\bredis\b/
 
 var AsyncResource;
 var executionAsyncId;
+var isSupported = false;
 
 try {
     var asyncHooks = require('async_hooks');
     if (typeof asyncHooks.AsyncResource.prototype.runInAsyncScope === 'function') {
         AsyncResource = asyncHooks.AsyncResource;
         executionAsyncId = asyncHooks.executionAsyncId;
+        isSupported = true;
     }
-} catch (e) { debug('not support'); }
+} catch (e) { debug('async_hooks does not support'); }
 
 function Command (command, args, callback, call_on_write) {
     this.command = command;
     this.args = args;
     this.buffer_args = false;
 
-    if (AsyncResource && typeof callback === 'function') {
+    if (isSupported && typeof callback === 'function') {
         var asyncResource = new AsyncResource('redis', executionAsyncId());
-        var callbackWrapper = function () {
+        this.callback = function () {
             try {
                 // asyncResource.runInAsyncScope(callback, this, ...arguments); // es6 rules not allow
                 var params = [callback, this];
@@ -36,7 +38,6 @@ function Command (command, args, callback, call_on_write) {
                 throw err;
             }
         };
-        this.callback = callbackWrapper;
     } else {
         this.callback = callback;
     }


### PR DESCRIPTION
# [AsyncLocalStorage] getStore() return undefine after call redis command

The [async_hooks](https://nodejs.org/dist/latest-v14.x/docs/api/async_hooks.html) module provides an API to track asynchronous resources. but in current version of node-redis, it cause missing `context` after executing redis command

##  Tesing code

```javascript
/* eslint-disable no-console */
const redis = require('redis')
const { AsyncLocalStorage } = require('async_hooks')
const express = require('express')

const client = redis.createClient({
  host: '127.0.0.1',
  port: 6379,
  password: 'xxxxx',
  db: 1
})

const asyncLocalStorage = new AsyncLocalStorage()

const app = express()

app.use((req, res, next) => {
  // prepare store
  asyncLocalStorage.enterWith({ now: new Date().getTime() })
  next()
})

app.use((req, res, next) => {
  // get store from asyncLocalStorage
  console.log(asyncLocalStorage.getStore()) // output: {now: 1615527591298}
  next()
})

app.use((req, res, next) => {
  client.get('foo', (err, data) => {
    if (err) {
      next(err)
    }
   // get store from asyncLocalStorage
    console.log(asyncLocalStorage.getStore()) // outout undefined
    next()
  })
})

app.use((req, res, next) => {
  // get store from asyncLocalStorage
  console.log(asyncLocalStorage.getStore()) // outout undefined
  next()
})

app.get('*', (req, res) => {
  res.send('nothing')
})

app.listen(8080, err => {
  if (err) {
    console.error(err)
  } else {
    console.log('Server listening on port 8080')
  }
})

```

## Tesing result

```shell
curl http://127.0.0.1
```

`Expect output:`
```shell
{ now: 1615527763957 }
{ now: 1615527763957 }
{ now: 1615527763957 }
```

`Actual output:`
```shell
{ now: 1615527763957 }
undefined
undefined
```

This patch for fixing the issue