### PR TITLE
commands-queue.ts: String length / byte length counting issue

### DIFF
--- a/lib/commands-queue.spec.ts
+++ b/lib/commands-queue.spec.ts
@@ -11,6 +11,6 @@ describe('Command Queue', () => {
     it('UTF-16 Byte length check (see #1628)', () => {
 	const encodeCommandInput = ["\u{1f91e}"];
 	const encoded = RedisCommandsQueue.encodeCommand(encodeCommandInput);
-	assert(encoded == "*1\r\n$2\r\n\u{1f91e}\r\n");
+	assert.equal(encoded, "*1\r\n$4\r\n\u{1f91e}\r\n");
     }); 
 });

--- a/lib/commands-queue.spec.ts
+++ b/lib/commands-queue.spec.ts
@@ -2,15 +2,26 @@ import { strict as assert } from 'assert';
 import RedisCommandsQueue from './commands-queue';
 
 describe('Command Queue', () => {
-    it('Command encodes correctly', () => {
-	const encodeCommandInput = ["TEST"];
-	const encoded = RedisCommandsQueue.encodeCommand(encodeCommandInput);
-	assert(encoded == "*1\r\n$4\r\nTEST\r\n");
-    });
+    describe('Encoding (see #1628)', () => {
+        it('1 byte', () => {
+            assert.equal(
+                RedisCommandsQueue.encodeCommand(['a', 'z']),
+                '*2\r\n$1\r\na\r\n$1\r\nz\r\n'
+            );
+        });
 
-    it('UTF-16 Byte length check (see #1628)', () => {
-	const encodeCommandInput = ["🤞", "🤞"];
-	const encoded = RedisCommandsQueue.encodeCommand(encodeCommandInput);
-	assert.equal(encoded, "*2\r\n$4\r\n🤞\r\n$4\r\n🤞\r\n");
-    }); 
+        it('2 bytes', () => {
+            assert.equal(
+                RedisCommandsQueue.encodeCommand(['א', 'ת']),
+                '*2\r\n$2\r\nא\r\n$2\r\nת\r\n'
+            );
+        });
+
+        it('4 bytes', () => {
+            assert.equal(
+                RedisCommandsQueue.encodeCommand(['🐣', '🐤']),
+                '*2\r\n$4\r\n🐣\r\n$4\r\n🐤\r\n'
+            );
+        });
+    });
 });

--- a/lib/commands-queue.spec.ts
+++ b/lib/commands-queue.spec.ts
@@ -1,0 +1,16 @@
+import { strict as assert } from 'assert';
+import RedisCommandsQueue from './commands-queue';
+
+describe('Command Queue', () => {
+    it('Command encodes correctly', () => {
+	const encodeCommandInput = ["TEST"];
+	const encoded = RedisCommandsQueue.encodeCommand(encodeCommandInput);
+	assert(encoded == "*1\r\n$4\r\nTEST\r\n");
+    });
+
+    it('UTF-16 Byte length check (see #1628)', () => {
+	const encodeCommandInput = ["\u{1f91e}"];
+	const encoded = RedisCommandsQueue.encodeCommand(encodeCommandInput);
+	assert(encoded == "*1\r\n$2\r\n\u{1f91e}\r\n");
+    }); 
+});

--- a/lib/commands-queue.spec.ts
+++ b/lib/commands-queue.spec.ts
@@ -9,8 +9,8 @@ describe('Command Queue', () => {
     });
 
     it('UTF-16 Byte length check (see #1628)', () => {
-	const encodeCommandInput = ["\u{1f91e}"];
+	const encodeCommandInput = ["🤞", "🤞"];
 	const encoded = RedisCommandsQueue.encodeCommand(encodeCommandInput);
-	assert.equal(encoded, "*1\r\n$4\r\n\u{1f91e}\r\n");
+	assert.equal(encoded, "*2\r\n$4\r\n🤞\r\n$4\r\n🤞\r\n");
     }); 
 });

--- a/lib/commands-queue.ts
+++ b/lib/commands-queue.ts
@@ -50,7 +50,7 @@ export default class RedisCommandsQueue {
 
         for (let i = 1; i < args.length; i++) {
             const str = args[i].toString();
-            encoded.push(`$${Buffer.byteLength(str)}`, str);
+            encoded.push(`$${str.length}`, str);
         }
 
         return encoded.join('\r\n') + '\r\n';

--- a/lib/commands-queue.ts
+++ b/lib/commands-queue.ts
@@ -49,8 +49,7 @@ export default class RedisCommandsQueue {
         ];
 
         for (let i = 1; i < args.length; i++) {
-            const str = args[i].toString();
-            encoded.push(`$${Buffer.byteLength(str)}`, str);
+            encoded.push(`$${Buffer.byteLength(args[i])}`, args[i]);
         }
 
         return encoded.join('\r\n') + '\r\n';

--- a/lib/commands-queue.ts
+++ b/lib/commands-queue.ts
@@ -50,7 +50,7 @@ export default class RedisCommandsQueue {
 
         for (let i = 1; i < args.length; i++) {
             const str = args[i].toString();
-            encoded.push(`$${str.length}`, str);
+            encoded.push(`$${Buffer.byteLength(str)}`, str);
         }
 
         return encoded.join('\r\n') + '\r\n';

--- a/lib/commands-queue.ts
+++ b/lib/commands-queue.ts
@@ -44,7 +44,7 @@ export default class RedisCommandsQueue {
     static encodeCommand(args: Array<string>): string {
         const encoded = [
             `*${args.length}`,
-            `$${args[0].length}`,
+            `$${Buffer.byteLength(args[0])}`,
             args[0]
         ];
 


### PR DESCRIPTION
Hopefully fixes #1628

### Description

Fixes using string length instead of byte length when encoding command
### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] ~~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~~ Nothing but bugfix, not needed
